### PR TITLE
Fix Registered Script Handles, CSS Classes & Form Lables

### DIFF
--- a/dead-simple-countdown-widget.php
+++ b/dead-simple-countdown-widget.php
@@ -42,7 +42,7 @@ add_action( 'widgets_init', 'dscw_countdown_register_widget' );
 function dscw_countdown_register_assets() {
 	// Front end JS
 	wp_register_script(
-		'dscw-countdown-timer-js',
+		'dead-simple-countdown-widget-js',
 		DSCW_COUNTDOWN_TIMER_URL . 'assets/front-end/js/countdown-timer.js',
 		array( 'jquery' ),
 		'1.0.0',
@@ -50,7 +50,7 @@ function dscw_countdown_register_assets() {
 	);
 	// Front end styles
 	wp_register_style(
-		'dscw-countdown-timer-styles',
+		'dead-simple-countdown-widget-styles',
 		DSCW_COUNTDOWN_TIMER_URL . 'assets/front-end/css/countdown-timer.css',
 		array(),
 		'1.0.0'

--- a/inc/countdown-widget.php
+++ b/inc/countdown-widget.php
@@ -47,31 +47,31 @@ if ( ! class_exists( 'Dead_Simple_CountDown_Widget' ) ) {
             <hr>
             <p>
                 <label for="<?php echo $this->get_field_id( 'end_date' ); ?>">
+                    End Date:
                     <input type="text" id="<?php echo $this->get_field_id( 'end_date' ); ?>"
                            name="<?php echo $this->get_field_name( 'end_date' ); ?>"
                            value="<?php echo $end_date ?>"
                            onclick="jQuery(this).datepicker();jQuery(this).datepicker('show');"
                     />
-
+                    <span style="display: block; font-size: 0.9em; margin-top: 4px; color: #656572;" >
+                        Date to count down to.
+                    </span>
                 </label>
             </p>
             <hr>
             <p>
                 <label for="<?php echo $this->get_field_id( 'expired_text' ); ?>">
+                    End Date Text:
                     <input type="text" id="<?php echo $this->get_field_id( 'expired_text' ); ?>"
                            name="<?php echo $this->get_field_name( 'expired_text' ); ?>"
                            value="<?php echo $expired_text ?>"
                     />
-
+                    <span style="display: block; font-size: 0.9em; margin-top: 4px; color: #656572;" >
+                        Text displayed when countdown expires.
+                    </span>
                 </label>
             </p>
 
-            <div class="tmd-countdown-timer-box">
-                <p class="tmd-countdown-items tmd-countdown-days"> Days</p>
-                <p class="tmd-countdown-items tmd-countdown-hours"> Hours</p>
-                <p class="tmd-countdown-items tmd-countdown-minutes"> Minutes</p>
-                <p class="tmd-countdown-items tmd-countdown-seconds"> Seconds</p>
-            </div>
 			<?php
 			echo ob_get_clean();
 		}

--- a/inc/countdown-widget.php
+++ b/inc/countdown-widget.php
@@ -110,7 +110,7 @@ if ( ! class_exists( 'Dead_Simple_CountDown_Widget' ) ) {
 
 			$content = '';
 			$content .= '<div 
-		                class="tmd-countdown-instance" 
+		                class="dscw-countdown-instance" 
 		                data-instance="' . $this->id . '" 
 		                data-end-date="' . $endDate . '" 
 		                data-expired-text="' . $expiredText . '"


### PR DESCRIPTION
Fixes:
 * Front-end JavaScript was being registered with the incorrect handle.
 * Missing labels for `'end_date'` and `'expired_text'` fields in the widget settings
 * Incorrect CSS class name prefix in widget output