### PR TITLE
Add Number Transition Animation

### DIFF
--- a/assets/front-end/js/countdown-timer.js
+++ b/assets/front-end/js/countdown-timer.js
@@ -126,12 +126,12 @@
 		 *
 		 * @param {jQuery} $element - jQuery object to animate.
 		 * @param {(number|string)} endPoint - Timestamp the animation will move toward.
-		 * @param {(number|string)} [transitionDuration=1500] - Number of milliseconds the animation will run for.
+		 * @param {(number|string)} [transitionDuration=2000] - Number of milliseconds the animation will run for.
 		 */
 		CountDownTimer.prototype.numberTransition = function ($element, endPoint, transitionDuration) {
 			// Transition numbers from 0 to the final number
 			$({numberCount: $element.text()}).animate({numberCount: endPoint}, {
-				duration: transitionDuration || 1500,
+				duration: transitionDuration || 2000,
 				step: function () {
 					$element.text(Math.floor(this.numberCount));
 				},

--- a/assets/front-end/js/countdown-timer.js
+++ b/assets/front-end/js/countdown-timer.js
@@ -88,17 +88,24 @@
 		 * @since 2.0.0
 		 *
 		 * @see CountDownTimer.render
+		 * @see CountDownTimer.calculateRemaining
 		 * @see CountDownTimer.showRemainingTime
+		 *
+		 * @return {number} `intervalID` of the timer or `0` if the timer already expired.
 		 */
 		CountDownTimer.prototype.start = function () {
-			// Reference to calling class
-			var self = this;
 
 			// Draw the timer
 			this.render();
 
-			this.timer = setInterval(function () {
-				// Run the actual countdown until it expires
+			if (this.calculateRemaining() < 0) {
+				this.expireTimer();
+				return 0;
+			}
+			// Reference to calling class
+			var self = this;
+			// Set the countdown to run every second and return `intervalID` for this timer.
+			return this.timer = setInterval(function () {
 				self.showRemainingTime();
 			}, 1000);
 		};
@@ -148,12 +155,29 @@
 				this.$numberMinutes.text(this.minutes);
 				this.$numberSeconds.text(this.seconds);
 
-			} else {
-				// The countdown expired. Stop future execution of this countdown.
-				clearInterval(this.timer);
-				// Set the expiration text and exit
-				this.$countDownBox.html('<h4 class="dscw-countdown-expired-text">' + this.expiredText + '</h4>');
-				// Finished
+			}
+		};
+
+		/**
+		 * Stops execution of a timer and replaces the displayed count with optional text.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param {number} [timer=this.timer] - Optional `intervalID` returned from `setInterval()` to clear.
+		 * @param {(string|false)} [displayText=this.expiredText] - Text to replace numbers shown or `false` for no text.
+		 */
+		CountDownTimer.prototype.expireTimer = function (timer, displayText) {
+			// If `timer` is null or undefined `timerID === this.timer`
+			var timerID = (null == timer) ? this.timer : timer;
+			// If `displayText` is null or undefined `text === this.expiredText`.
+			var text = (null == displayText) ? this.expiredText : displayText;
+
+			// Stop updating the timer.
+			clearInterval(timerID);
+
+			// Replace numbers displayed with `text` if not falsey.
+			if (text) {
+				this.$countDownBox.html('<h4 class="dscw-countdown-expired-text">' + text + '</h4>');
 			}
 		};
 

--- a/assets/front-end/js/countdown-timer.js
+++ b/assets/front-end/js/countdown-timer.js
@@ -89,6 +89,7 @@
 		 *
 		 * @see CountDownTimer.render
 		 * @see CountDownTimer.calculateRemaining
+		 * @see CountDownTimer.numberTransition
 		 * @see CountDownTimer.showRemainingTime
 		 *
 		 * @return {number} `intervalID` of the timer or `0` if the timer already expired.
@@ -98,16 +99,46 @@
 			// Draw the timer
 			this.render();
 
+			// Set expired text if there's no time left
 			if (this.calculateRemaining() < 0) {
 				this.expireTimer();
 				return 0;
 			}
+
+			// Animate the transition of the numbers from 0 to remaining value
+			this.numberTransition(this.$numberDays, this.days);
+			this.numberTransition(this.$numberHours, this.hours);
+			this.numberTransition(this.$numberMinutes, this.minutes);
+			this.numberTransition(this.$numberSeconds, this.seconds);
+
 			// Reference to calling class
 			var self = this;
 			// Set the countdown to run every second and return `intervalID` for this timer.
 			return this.timer = setInterval(function () {
 				self.showRemainingTime();
 			}, 1000);
+		};
+
+		/**
+		 * Animates the number inside an element from it's value to the value of `endPoint`.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param {jQuery} $element - jQuery object to animate.
+		 * @param {(number|string)} endPoint - Timestamp the animation will move toward.
+		 * @param {(number|string)} [transitionDuration=1500] - Number of milliseconds the animation will run for.
+		 */
+		CountDownTimer.prototype.numberTransition = function ($element, endPoint, transitionDuration) {
+			// Transition numbers from 0 to the final number
+			$({numberCount: $element.text()}).animate({numberCount: endPoint}, {
+				duration: transitionDuration || 1500,
+				step: function () {
+					$element.text(Math.floor(this.numberCount));
+				},
+				complete: function () {
+					$element.text(this.numberCount);
+				}
+			});
 		};
 
 		/**


### PR DESCRIPTION
Adds a new method to the `CountDownTimer` prototype that animates the transition of numbers from default start time to reaming time.

### Changed:
* Moved logic to expire the timer into it's own method.
* Return the timer's `intervalID` from `start()` method or `0` if the timer is already expired.

### New:
* Add method to animate number transitions & run it on `start()`. 