### PR TITLE
Refator & Modify Theme Styles

### DIFF
--- a/assets/front-end/css/countdown-timer.css
+++ b/assets/front-end/css/countdown-timer.css
@@ -40,10 +40,15 @@
 .dscw-countdown-theme-simple-blue-white .dscw-countdown-theme-inner h1,
 .dscw-countdown-theme-simple-blue-white .dscw-countdown-theme-inner h2,
 .dscw-countdown-theme-simple-blue-white .dscw-countdown-theme-inner h3,
-.dscw-countdown-theme-simple-blue-white .dscw-countdown-theme-inner h4,
+.dscw-countdown-theme-simple-blue-white .dscw-countdown-theme-inner h4 {
+	color: #0093b6;
+	font-weight: 600;
+	border: none;
+}
+
 .dscw-countdown-theme-simple-blue-white .dscw-countdown-theme-inner p,
 .dscw-countdown-theme-simple-blue-white .dscw-countdown-theme-inner li {
-	color: #086788;
+	color: #2b93b7;
 	font-weight: 600;
 	border: none;
 }
@@ -62,7 +67,7 @@
 	margin: 5px auto 10px auto;
 }
 
-.dscw-countdown-theme-simple-blue-white .dscw-countdown-expired-text {
+.dscw-countdown-theme-simple-blue-white h4.dscw-countdown-expired-text {
 	color: #dd1c1a;
 }
 
@@ -95,6 +100,6 @@
 	margin: 5px auto 10px auto;
 }
 
-.dscw-countdown-theme-simple-black-white .dscw-countdown-expired-text {
+.dscw-countdown-theme-simple-black-white h4.dscw-countdown-expired-text {
 	color: #dd1c1a;
 }

--- a/assets/front-end/css/countdown-timer.css
+++ b/assets/front-end/css/countdown-timer.css
@@ -23,10 +23,6 @@
 	border-radius: 3px;
 }
 
-.dscw-countdown-timer-box {
-	font-weight: 600;
-}
-
 .dscw-countdown-timer-box .dscw-countdown-timer-box-items {
 	display: inline-block;
 	margin: 5px;

--- a/assets/front-end/css/countdown-timer.css
+++ b/assets/front-end/css/countdown-timer.css
@@ -37,43 +37,43 @@
 }
 
 /* Light Theme */
-.dscw-countdown-theme-light {
+.dscw-countdown-theme-simple-blue-white {
 	color: #086788;
 }
 
-.dscw-countdown-theme-light .dscw-countdown-theme-inner {
+.dscw-countdown-theme-simple-blue-white .dscw-countdown-theme-inner {
 	background-color: #fafafa;
 	border: solid 3px #06aed5;
 }
 
-.dscw-countdown-theme-light .dscw-countdown-timer-box {
+.dscw-countdown-theme-simple-blue-white .dscw-countdown-timer-box {
 	border-bottom: 1px solid;
 	border-color: #06aed5;
 	border-top: 1px solid;
 	padding: 4px 0;
 }
 
-.dscw-countdown-theme-light .dscw-countdown-expired-text {
+.dscw-countdown-theme-simple-blue-white .dscw-countdown-expired-text {
 	color: #dd1c1a;
 }
 
 /* Dark Theme */
-.dscw-countdown-theme-dark {
+.dscw-countdown-theme-simple-black-white {
 	color: #fafafa;
 }
 
-.dscw-countdown-theme-dark .dscw-countdown-theme-inner {
+.dscw-countdown-theme-simple-black-white .dscw-countdown-theme-inner {
 	background-color: #0c0c0c;
 	border: solid 3px #fafafa;
 }
 
-.dscw-countdown-theme-dark .dscw-countdown-timer-box {
+.dscw-countdown-theme-simple-black-white .dscw-countdown-timer-box {
 	border-bottom: 1px solid;
 	border-color: #fafafa;
 	border-top: 1px solid;
 	padding: 4px 0;
 }
 
-.dscw-countdown-theme-dark .dscw-countdown-expired-text {
+.dscw-countdown-theme-simple-black-white .dscw-countdown-expired-text {
 	color: #dd1c1a;
 }

--- a/assets/front-end/css/countdown-timer.css
+++ b/assets/front-end/css/countdown-timer.css
@@ -15,13 +15,16 @@
 	margin: 0.8em auto;
 }
 
+.dscw-countdown-instance ul {
+	list-style: none;
+}
+
 .dscw-countdown-timer-box-container {
 	border-radius: 3px;
 }
 
 .dscw-countdown-timer-box {
 	font-weight: 600;
-	margin: 15px auto;
 }
 
 .dscw-countdown-timer-box .dscw-countdown-timer-box-items {
@@ -37,8 +40,16 @@
 }
 
 /* Light Theme */
-.dscw-countdown-theme-simple-blue-white {
+
+.dscw-countdown-theme-simple-blue-white .dscw-countdown-theme-inner h1,
+.dscw-countdown-theme-simple-blue-white .dscw-countdown-theme-inner h2,
+.dscw-countdown-theme-simple-blue-white .dscw-countdown-theme-inner h3,
+.dscw-countdown-theme-simple-blue-white .dscw-countdown-theme-inner h4,
+.dscw-countdown-theme-simple-blue-white .dscw-countdown-theme-inner p,
+.dscw-countdown-theme-simple-blue-white .dscw-countdown-theme-inner li {
 	color: #086788;
+	font-weight: 600;
+	border: none;
 }
 
 .dscw-countdown-theme-simple-blue-white .dscw-countdown-theme-inner {
@@ -47,10 +58,12 @@
 }
 
 .dscw-countdown-theme-simple-blue-white .dscw-countdown-timer-box {
-	border-bottom: 1px solid;
-	border-color: #06aed5;
-	border-top: 1px solid;
+	border-bottom: 1px solid #06aed5;
+	border-top: 1px solid #06aed5;
+	border-left: none;
+	border-right: none;
 	padding: 4px 0;
+	margin: 5px auto 10px auto;
 }
 
 .dscw-countdown-theme-simple-blue-white .dscw-countdown-expired-text {
@@ -58,20 +71,32 @@
 }
 
 /* Dark Theme */
-.dscw-countdown-theme-simple-black-white {
+
+.dscw-countdown-theme-simple-black-white .dscw-countdown-theme-inner h1,
+.dscw-countdown-theme-simple-black-white .dscw-countdown-theme-inner h2,
+.dscw-countdown-theme-simple-black-white .dscw-countdown-theme-inner h3,
+.dscw-countdown-theme-simple-black-white .dscw-countdown-theme-inner h4,
+.dscw-countdown-theme-simple-black-white .dscw-countdown-theme-inner p,
+.dscw-countdown-theme-simple-black-white .dscw-countdown-theme-inner li {
 	color: #fafafa;
+	font-weight: 600;
+	border: none;
+
 }
 
 .dscw-countdown-theme-simple-black-white .dscw-countdown-theme-inner {
+	color: #fafafa;
 	background-color: #0c0c0c;
 	border: solid 3px #fafafa;
 }
 
 .dscw-countdown-theme-simple-black-white .dscw-countdown-timer-box {
-	border-bottom: 1px solid;
-	border-color: #fafafa;
-	border-top: 1px solid;
+	border-bottom: 1px solid #fafafa;
+	border-top: 1px solid #fafafa;
+	border-left: none;
+	border-right: none;
 	padding: 4px 0;
+	margin: 5px auto 10px auto;
 }
 
 .dscw-countdown-theme-simple-black-white .dscw-countdown-expired-text {

--- a/assets/front-end/css/countdown-timer.css
+++ b/assets/front-end/css/countdown-timer.css
@@ -1,3 +1,9 @@
+.dscw-countdown-widget {
+	max-width: 400px;
+	margin-left: auto;
+	margin-right: auto;
+}
+
 .dscw-countdown-instance {
 	border-radius: 2px;
 	font-size: 16px;

--- a/assets/front-end/js/countdown-timer.js
+++ b/assets/front-end/js/countdown-timer.js
@@ -223,11 +223,19 @@ var CountDownTimer = ( function() {
 		// Check if there is still time left before the countdown expires
 		if ( 0 < this.calculateRemaining() ) {
 
-			// Update the displayed numbers
-			this.$numberDays.text( this.remaining.days );
-			this.$numberHours.text( this.remaining.hours );
-			this.$numberMinutes.text( this.remaining.minutes );
-			this.$numberSeconds.text( this.remaining.seconds );
+			// Update the displayed numbers if they changed
+			if ( this.remaining.days !== Number( this.$numberDays.text() ) ) {
+				this.$numberDays.text( this.remaining.days );
+			}
+			if ( this.remaining.hours !== Number( this.$numberHours.text() ) ) {
+				this.$numberHours.text( this.remaining.hours );
+			}
+			if ( this.remaining.minutes !== Number( this.$numberMinutes.text() ) ) {
+				this.$numberMinutes.text( this.remaining.minutes );
+			}
+			if ( this.remaining.seconds !== Number( this.$numberSeconds.text() ) ) {
+				this.$numberSeconds.text( this.remaining.seconds );
+			}
 		}
 	};
 

--- a/inc/class-dead-simple-countdown-widget.php
+++ b/inc/class-dead-simple-countdown-widget.php
@@ -48,9 +48,9 @@ if ( ! class_exists( 'Dead_Simple_CountDown_Widget' ) ) {
 			 *
 			 * @since 2.0.0
 			 *
-			 * @param string 'light' Default theme key.
+			 * @param string 'dscw-simple-blue-white' Default theme key.
 			 */
-			$default_theme = apply_filters( 'dscw_default_widget_theme', 'light' );
+			$default_theme = apply_filters( 'dscw_default_widget_theme', 'dscw-simple-blue-white' );
 
 			$active_theme = ! empty( $instance['theme'] ) ? $instance['theme'] : $default_theme;
 
@@ -60,9 +60,9 @@ if ( ! class_exists( 'Dead_Simple_CountDown_Widget' ) ) {
 			$expired_text = ! empty( $instance['expired_text'] ) ? $instance['expired_text'] : '';
 
 			$available_themes = array(
-				'light' => 'Light',
-				'dark'  => 'Dark',
-				'none'  => 'None',
+				'dscw-simple-blue-white'  => 'Simple Blue/White',
+				'dscw-simple-black-white' => 'Simple Black/White',
+				'none'                    => 'None',
 			);
 
 			/**
@@ -199,11 +199,11 @@ if ( ! class_exists( 'Dead_Simple_CountDown_Widget' ) ) {
 
 			// Check if we are using a theme and set the CSS class accordingly.
 			switch ( $instance['theme'] ) {
-				case 'light':
-					$container_class = 'dscw-countdown-theme-light ';
+				case 'dscw-simple-blue-white':
+					$container_class = 'dscw-countdown-theme-simple-blue-white ';
 					break;
-				case 'dark':
-					$container_class = 'dscw-countdown-theme-dark ';
+				case 'dscw-simple-black-white':
+					$container_class = 'dscw-countdown-theme-simple-black-white ';
 					break;
 				default:
 					$container_class = '';


### PR DESCRIPTION
Renames built in themes, making the internal theme key more unique, changes the displayed theme name and makes some CSS selectors more specific to work around opinionated themes. Additionally, the `CountDownTimer`'s `showRemainingTime` prototype method was updated to only modify the DOM nodes holding numbers that actually changed ( as apposed to updating the text content every time.) 

### New
* `CountDownTimer.prototype.showRemainingTime` now only updates a node's text if it has changed since last draw.
* Add `400px` `max-width` and `auto` left and right margins on the widget output. This is intended to stay sane looking in very wide widget areas.

### Changed
* Renamed the built in themes and associated keys.
* Some CSS selectors have been made more specific to help maintain styles when used with opinionated themes.
* Colors used by the blue/white theme have been modified slightly.
